### PR TITLE
doc: added description about versioning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ On hardened setups which default to PIC builds, the following flag is required:
 
     $ go install -ldflags '-extldflags=-fno-PIC' github.com/pixiv/go-thumber/thumberd
 
+And the versioning is possible on build-time.
+
+    $ go install -ldflags '-X main.version v1.3' github.com/pixiv/go-thumber/thumberd
 
 ### Usage
 


### PR DESCRIPTION
Now `thumberd` seems to not have own version by default.

BAC, Is using the following build-option premised?

```
-ldflags '-X main.version v1.3'
```

If so, I think it is good for non-golang-users to describe about it. How about you?