### PR TITLE
[WIP] Avoid cgocheck in Go 1.6

### DIFF
--- a/jpeg/jpeg_read.go
+++ b/jpeg/jpeg_read.go
@@ -15,6 +15,10 @@ static void c_jpeg_create_decompress(j_decompress_ptr dinfo) {
 	jpeg_create_decompress(dinfo);
 }
 
+static JDIMENSION _jpeg_read_raw_data(j_decompress_ptr dinfo, uintptr_t data, JDIMENSION max_lines) {
+	return jpeg_read_raw_data(dinfo, (JSAMPIMAGE)data, max_lines);
+}
+
 void error_panic(j_common_ptr dinfo);
 
 void sourceInit(struct jpeg_decompress_struct*);
@@ -311,7 +315,7 @@ func ReadJPEG(src io.Reader, params DecompressionParameters) (img *YUVImage, err
 			}
 		}
 		// Get the data
-		row += C.jpeg_read_raw_data(dinfo, C.JSAMPIMAGE(unsafe.Pointer(&yuvPtr[0])), C.JDIMENSION(2*iMCURows))
+		row += C._jpeg_read_raw_data(dinfo, C.uintptr_t(uintptr(unsafe.Pointer(&yuvPtr[0]))), C.JDIMENSION(2*iMCURows))
 	}
 
 	// Clean up

--- a/jpeg/jpeg_read_test.go
+++ b/jpeg/jpeg_read_test.go
@@ -1,0 +1,41 @@
+package jpeg
+
+import (
+	"os"
+	"testing"
+)
+
+type testImage struct {
+	Path          string
+	Width, Height int
+}
+
+var testImages = []testImage{
+	testImage{
+		"../test-image/test001.jpg",
+		1000,
+		750,
+	},
+}
+
+func TestRead(t *testing.T) {
+	for _, testImage := range testImages {
+		src, err := os.Open("../test-image/test001.jpg")
+		if err != nil {
+			t.Errorf("open: %v", err)
+			continue
+		}
+		img, err := ReadJPEG(src, DecompressionParameters{})
+		if err != nil {
+			t.Errorf("ReadJPEG: %v", err)
+			continue
+		}
+
+		if testImage.Width != img.Width {
+			t.Errorf("width: %d, expected: %d", img.Width, testImage.Width)
+		}
+		if testImage.Height != img.Height {
+			t.Errorf("height: %d, expected: %d", img.Height, testImage.Height)
+		}
+	}
+}


### PR DESCRIPTION
This is not good, but it can skip cgochecks.

- [x] jpeg_read
- [ ] jpeg_write
- [ ] swscale